### PR TITLE
ci: remove `.npmrc` to avoid failure in npm login

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npm.taobao.org


### PR DESCRIPTION
Fixes:
- remove `.npmrc` to avoid failure in npm login